### PR TITLE
Fix unnecessary script imports.

### DIFF
--- a/BESL.Web/Views/Shared/Partials/_ScriptsImportPartial.cshtml
+++ b/BESL.Web/Views/Shared/Partials/_ScriptsImportPartial.cshtml
@@ -1,6 +1,5 @@
 ﻿<environment include="Development">
     <script src="~/lib/jquery/jquery.min.js"></script>
-    <script src="~/lib/bootstrap/js/bootstrap.bundle.min.js"></script>
     <script src="~/lib/bootstrap/js/bootstrap.min.js"></script>
     <script src="~/lib/aspnet-signalr/dist/browser/signalr.min.js"></script>
     <script src="~/lib/jquery-ajax-unobtrusive/dist/jquery.unobtrusive-ajax.min.js"></script>
@@ -11,10 +10,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js"
             asp-fallback-src="~/lib/jquery/jquery.min.js"
             asp-fallback-test="window.jQuery"
-            crossorigin="anonymous"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.bundle.min.js"
-            asp-fallback-src="~/lib/bootstrap/js/bootstrap.bundle.min.js"
-            asp-fallback-test="window.jQuery && window.jQuery.fn && window.jQuery.fn.modal"
             crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"
             asp-fallback-src="~/lib/bootstrap/js/bootstrap.min.js"


### PR DESCRIPTION
Fixes: #12 
Due to conficting bootstrap script imports, dropdown menu functionality was broken, because of bootstrap.bundle.min.js