### PR TITLE
Upload code coverage reports to `CodeCov` and as a workflow run artifact.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,14 @@ jobs:
 
       - name: Run Unit Tests
         run: ./build.sh rununittests --configuration Debug
+
+      - name: Upload Code Coverage Report as Artifact
+        uses: actions/upload-artifact@v2.2.4
+        with: 
+          name: coverage-report
+          path: ./artifacts/*_coverage.xml
       
-      - name: Publish Code Coverage Report
+      - name: Publish Code Coverage Report to CodeCov
         run: ./build.sh uploadcodecoverageartifact
         env:
           CodeCovToken: ${{ secrets.CodeCovToken }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,11 @@ jobs:
       - name: Run Unit Tests
         run: ./build.sh rununittests --configuration Debug
       
+      - name: Publish Code Coverage Report
+        run ./build.sh uploadcodecoverageartifact
+        env:
+          CodeCovToken: ${{ secrets.CodeCovToken }}
+      
       - name: Publish Docker Image
         run: ./build.sh publishdockerimage --configuration Release
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         run: ./build.sh rununittests --configuration Debug
       
       - name: Publish Code Coverage Report
-        run ./build.sh uploadcodecoverageartifact
+        run: ./build.sh uploadcodecoverageartifact
         env:
           CodeCovToken: ${{ secrets.CodeCovToken }}
       

--- a/.gitignore
+++ b/.gitignore
@@ -139,6 +139,9 @@ _TeamCity*
 *.coverage
 *.coveragexml
 
+# CodeCov
+codecov*
+
 # NCrunch
 _NCrunch_*
 .*crunch*.local.xml

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -6,6 +6,10 @@
     "build": {
       "type": "object",
       "properties": {
+        "CodeCovToken": {
+          "type": "string",
+          "description": "The CodeCov token used for authenticating when uploading coverage reports"
+        },
         "Configuration": {
           "type": "string",
           "description": "Configuration to build - Default is 'Debug' (local) or 'Release' (server)",
@@ -77,7 +81,8 @@
               "Compile",
               "PublishDockerImage",
               "Restore",
-              "RunUnitTests"
+              "RunUnitTests",
+              "UploadCodeCoverageArtifact"
             ]
           }
         },
@@ -96,7 +101,8 @@
               "Compile",
               "PublishDockerImage",
               "Restore",
-              "RunUnitTests"
+              "RunUnitTests",
+              "UploadCodeCoverageArtifact"
             ]
           }
         },

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ BESL is an online eSports league for competitive tournaments on various games an
 -   Moq
 -   MockQueryable
 -   Coverlet
+-   Polly
+-   CodeCov
 
 # ⚙️ Local setup using Docker
 

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -167,7 +167,7 @@ class Build : NukeBuild
 
             ControlFlow.Assert(!string.IsNullOrWhiteSpace(scriptPath), "'CodeCov' uploader is not present.");
             using var changePermissionsProcess = StartShell($"chmod +x {scriptPath}");
-            using var coverageReportUploadProcess = StartShell($"{scriptPath} -t {CodeCovToken}", RootDirectory, logOutput: true);
+            using var coverageReportUploadProcess = StartShell($@"{scriptPath} -t {CodeCovToken}", RootDirectory, logOutput: true);
             Thread.Sleep(1000);
         });
 
@@ -177,16 +177,15 @@ class Build : NukeBuild
         {
             throw new ArgumentNullException(nameof(downloadPath));
         }
-        
+
         var process = Environment.OSVersion.Platform switch
         {
-            PlatformID.Win32Windows => StartShell(
-                "Invoke-WebRequest -Uri https://uploader.codecov.io/latest/windows/codecov.exe -Outfile codecov.exe", RootDirectory),
-            PlatformID.Unix => StartShell("curl -Os https://uploader.codecov.io/latest/linux/codecov", RootDirectory),
-            PlatformID.MacOSX => StartShell("curl -Os https://uploader.codecov.io/latest/macos/codecov", RootDirectory),
+            PlatformID.Win32NT => StartProcess("powershell", "Invoke-WebRequest -Uri https://uploader.codecov.io/latest/windows/codecov.exe -Outfile codecov.exe", RootDirectory, logOutput: true),
+            PlatformID.Unix => StartShell("curl -Os https://uploader.codecov.io/latest/linux/codecov", RootDirectory, logOutput: true),
+            PlatformID.MacOSX => StartShell("curl -Os https://uploader.codecov.io/latest/macos/codecov", RootDirectory, logOutput: true),
             _ => throw new PlatformNotSupportedException()
         };
-        
+
         process.WaitForExit();
         return process.ExitCode;
     }

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Nuke.Common" Version="5.1.2" />
     <PackageReference Include="Nuke.GitHub" Version="2.0.0" />
+    <PackageReference Include="Polly" Version="7.2.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Resolves #31 

After switching from `appveyor` to `GitHub Actions`, the code coverage reports were not uploaded to `CodeCov`.
This PR introduced a new `NUKE` target which takes care of retrieving the latest `uploader` script from `CodeCov` and uploading the generated report via a github secret token. 

The coverage reports is always uploaded as an artifact for the workflow run, but for `CodeCov` reports are pushen only for the `master` branch.

Also this PR does not make any integrity checks for the `uploader` script, but this will be done on a separate PR,